### PR TITLE
pandoc@1.14.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,27 @@
-FROM ubuntu
+FROM haskell:7.10
+
 MAINTAINER James Gregory <james@jagregory.com>
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe" > /etc/apt/sources.list
-
-# install haskell
-RUN apt-get update -y && apt-get install -y haskell-platform
+# will ease up the update process
+# updating this env variable will trigger the automatic build of the Docker image
+ENV PANDOC_VERSION "1.14.0.4"
 
 # install pandoc
-RUN cabal update && cabal install pandoc
+RUN cabal update && cabal install pandoc-${PANDOC_VERSION}
 
 # install latex packages
-RUN apt-get update -y && apt-get install -y texlive-latex-base texlive-xetex latex-xcolor texlive-math-extra texlive-latex-extra texlive-fonts-extra biblatex curl wget git fontconfig make
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends \
+    texlive-latex-base \
+    texlive-xetex latex-xcolor \
+    texlive-math-extra \
+    texlive-latex-extra \
+    texlive-fonts-extra \
+    biblatex \
+    fontconfig
 
-RUN mkdir -p /source
 WORKDIR /source
 
 ENTRYPOINT ["/.cabal/bin/pandoc"]
+
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -y \
     texlive-math-extra \
     texlive-latex-extra \
     texlive-fonts-extra \
-    biblatex \
+    texlive-bibtex-extra \
     fontconfig
 
 WORKDIR /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN apt-get update -y \
 
 WORKDIR /source
 
-ENTRYPOINT ["/.cabal/bin/pandoc"]
+ENTRYPOINT ["/root/.cabal/bin/pandoc"]
 
 CMD ["--help"]


### PR DESCRIPTION
- inherits from haskell official image
- install only texlive packages (not unused ones)
- install a specific, env based, pandoc version