### PR TITLE
Install security certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN cabal update && cabal install pandoc-${PANDOC_VERSION}
 # install latex packages
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends \
+    ca-certificates \
     texlive-latex-base \
     texlive-xetex latex-xcolor \
     texlive-math-extra \


### PR DESCRIPTION
So pandoc can properly fetch assets over https when communicating with
sites that have valid security certificates. See
https://github.com/briandk/pandoc-image-bug for reference